### PR TITLE
[DOC-13248]: Clarify Prerequisites For Operator Scaling

### DIFF
--- a/modules/ROOT/pages/howto-mds.adoc
+++ b/modules/ROOT/pages/howto-mds.adoc
@@ -36,6 +36,14 @@ Different classes may have different scales to handle different workloads on dif
 The xref:resource/couchbasecluster.adoc#couchbaseclusters-spec-servers-pod[`couchbaseclusters.spec.servers.pod`] template can even allow execution on different hardware types.
 
 <.> xref:resource/couchbasecluster.adoc#couchbaseclusters-spec-servers-name[`couchbaseclusters.spec.servers.name`] must be a unique per-server class.
++
+[IMPORTANT]
+.Changing cluster configurations
+====
+When changing an existing cluster configuration (for example, relocating the query service from nodes that currently host both query and index services onto dedicated nodes).
+ 
+it is important to change `couchbaseclusters.spec.servers.name`  to prevent name clashes during the upgrade process.
+====
 
 <.> xref:resource/couchbasecluster.adoc#couchbaseclusters-spec-servers-size[`couchbaseclusters.spec.servers.size`] is the number of pods to create per-server class.
 This can be independently scaled per-server class.

--- a/modules/ROOT/pages/howto-mds.adoc
+++ b/modules/ROOT/pages/howto-mds.adoc
@@ -40,9 +40,8 @@ The xref:resource/couchbasecluster.adoc#couchbaseclusters-spec-servers-pod[`couc
 [IMPORTANT]
 .Changing cluster configurations
 ====
-When changing an existing cluster configuration (for example, relocating the query service from nodes that currently host both query and index services onto dedicated nodes).
- 
-it is important to change `couchbaseclusters.spec.servers.name`  to prevent name clashes during the upgrade process.
+When changing an existing cluster configuration (for example, relocating the query service from nodes that currently host both query and index services onto dedicated nodes),
+ it is important to change `couchbaseclusters.spec.servers.name`  to prevent name clashes during the upgrade process.
 ====
 
 <.> xref:resource/couchbasecluster.adoc#couchbaseclusters-spec-servers-size[`couchbaseclusters.spec.servers.size`] is the number of pods to create per-server class.


### PR DESCRIPTION
Added a note to highlight the importance of updating `couchbaseclusters.spec.servers.name` while scaling clusters to avoid name clashes during upgrades.

You can preview the page here:

https://preview.docs-test.couchbase.com/docs-operator-DOC-13248-Clarify-Prerequisites-For-Operator-Scaling/operator/current/howto-mds.html

If you need a password to access the preview site, we keep them here:

https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords