### PR TITLE
Doc 13386

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,5 +1,5 @@
 name: operator
-title: Autonomous Operator
+title: Kubernetes Operator
 version: '2.8'
 prerelease: false
 start_page: ROOT:overview.adoc

--- a/modules/ROOT/pages/overview.adoc
+++ b/modules/ROOT/pages/overview.adoc
@@ -1,6 +1,6 @@
 = Introduction
 
-The integration of Couchbase Server with cloud-native technologies, facilitated by the Couchbase Kubernetes Operator (Autonomous Operator) provides a truly cloud-native database solution.
+The integration of Couchbase Server with cloud-native technologies, facilitated by the Couchbase Kubernetes (Autonomous) Operator provides a truly cloud-native database solution.
 This integration empowers organizations to build and run scalable stateful applications in modern, dynamic environments such as public, private, and hybrid clouds.
 Containers, service meshes, microservices, immutable infrastructure, and declarative APIs exemplify this approach.
 

--- a/modules/ROOT/pages/overview.adoc
+++ b/modules/ROOT/pages/overview.adoc
@@ -1,6 +1,6 @@
 = Introduction
 
-The Couchbase Cloud-Native Database is the native integration of Couchbase Server with cloud-native technologies, facilitated by the Couchbase Kubernetes Operator.
+The integration of Couchbase Server with cloud-native technologies, facilitated by the Couchbase Kubernetes Operator (Autonomous Operator) provides a truly cloud-native database solution.
 This integration empowers organizations to build and run scalable stateful applications in modern, dynamic environments such as public, private, and hybrid clouds.
 Containers, service meshes, microservices, immutable infrastructure, and declarative APIs exemplify this approach.
 

--- a/modules/ROOT/partials/couchbase-operator-release-notes-2.8.0.adoc
+++ b/modules/ROOT/partials/couchbase-operator-release-notes-2.8.0.adoc
@@ -5,7 +5,7 @@
 
 *https://jira.issues.couchbase.com/browse/K8S-3558[K8S-3558^]*::
 
-Operator commences an In-place Upgrade when the cluster is under-resourced.
+Couchbase Autonomous Operator commences an In-place Upgrade when the cluster is under-resourced.
 
 *https://jira.issues.couchbase.com/browse/K8S-3579[K8S-3579^]*::
 

--- a/modules/ROOT/partials/couchbase-operator-release-notes-2.8.0.adoc
+++ b/modules/ROOT/partials/couchbase-operator-release-notes-2.8.0.adoc
@@ -45,7 +45,7 @@ Operator loses track of pending Pods when an Eviction of the Operator Pod occurs
 
 *https://jira.issues.couchbase.com/browse/K8S-3655[K8S-3655^]*::
 
- Clear Upgrade condition if the Operator isn't performing an upgrade.
+ Clear Upgrade condition if the Operator is not performing an upgrade.
 
 *https://jira.issues.couchbase.com/browse/K8S-3659[K8S-3659^]*::
 

--- a/modules/ROOT/partials/couchbase-operator-release-notes-2.8.0.adoc
+++ b/modules/ROOT/partials/couchbase-operator-release-notes-2.8.0.adoc
@@ -87,6 +87,6 @@ Metric `couchbase_operator_cpu_under_management` is incorrectly showing 0.
 
 *https://jira.issues.couchbase.com/browse/K8S-3910[K8S-3910^]*::
 
-Operator tries to migrate storage backend of buckets even before couchbase cluster is in 7.6.0+.
+Operator tries to migrate storage backend of buckets even before Couchbase cluster is in 7.6.0+.
 
 |===

--- a/modules/ROOT/partials/couchbase-operator-release-notes-2.8.0.adoc
+++ b/modules/ROOT/partials/couchbase-operator-release-notes-2.8.0.adoc
@@ -9,7 +9,7 @@ Couchbase Autonomous Operator commences an In-place Upgrade when the cluster is 
 
 *https://jira.issues.couchbase.com/browse/K8S-3579[K8S-3579^]*::
 
-Operator tries to change invalid bucket configurations in a loop.
+Couchbase Autonomous Operator tries to change invalid bucket configurations in a loop.
 
 *https://jira.issues.couchbase.com/browse/K8S-3591[K8S-3591^]*::
 

--- a/modules/ROOT/partials/couchbase-operator-release-notes-2.8.0.adoc
+++ b/modules/ROOT/partials/couchbase-operator-release-notes-2.8.0.adoc
@@ -2,54 +2,66 @@
 [#fixed-issues-v280]
 === Fixed Issues
 
-[#table-fixed-issues-v280,cols="25,66"]
-|===
-| Issue | Description
 
-a| https://jira.issues.couchbase.com/browse/K8S-3558[K8S-3558^]
-a| *Summary:* Operator commences an In-place Upgrade when the cluster is under-resourced.
+*https://jira.issues.couchbase.com/browse/K8S-3558[K8S-3558^]*::
 
-a| https://jira.issues.couchbase.com/browse/K8S-3579[K8S-3579^]
-a| *Summary:* Operator tries to change invalid bucket configurations in a loop.
+Operator commences an In-place Upgrade when the cluster is under-resourced.
 
-a| https://jira.issues.couchbase.com/browse/K8S-3591[K8S-3591^]
-a| *Summary:* Operator crashes if Incremental Backup is missing schedule.
+*https://jira.issues.couchbase.com/browse/K8S-3579[K8S-3579^]*::
 
-a| https://jira.issues.couchbase.com/browse/K8S-3596[K8S-3596^]
-a| *Summary:* Crash in Operator due to invalid memory access.
+Operator tries to change invalid bucket configurations in a loop.
 
-a| https://jira.issues.couchbase.com/browse/K8S-3605[K8S-3605^]
-a| *Summary:* Upgrade Swap Rebalance is retried with different parameters on Operator Pod deletion.
+*https://jira.issues.couchbase.com/browse/K8S-3591[K8S-3591^]*::
 
-a| https://jira.issues.couchbase.com/browse/K8S-3609[K8S-3609^]
-a| *Summary:*  Hibernation fails to bring back any Pod with error extracting image version.
+Operator crashes if Incremental Backup is missing schedule.
 
-a| https://jira.issues.couchbase.com/browse/K8S-3621[K8S-3621^]
-a| *Summary:* Shadowed Secret did not get updated.
+*https://jira.issues.couchbase.com/browse/K8S-3596[K8S-3596^]*::
 
-a| https://jira.issues.couchbase.com/browse/K8S-3632[K8S-3632^]
-a| *Summary:* Unable to set -1 for Collection-level `maxTTL`.
+Crash in Operator due to invalid memory access.
 
-a| https://jira.issues.couchbase.com/browse/K8S-3639[K8S-3639^]
-a| *Summary:* Operator loses track of pending Pods when an Eviction of the Operator Pod occurs.
+*https://jira.issues.couchbase.com/browse/K8S-3605[K8S-3605^]*::
 
-a| https://jira.issues.couchbase.com/browse/K8S-3641[K8S-3641^]
-a| *Summary:*  Crash in `handleVolumeExpansion` if `enableOnlineVolumeExpansion` is True but no Volume Mounts configured.
+Upgrade Swap Rebalance is retried with different parameters on Operator Pod deletion.
 
-a| https://jira.issues.couchbase.com/browse/K8S-3655[K8S-3655^]
-a| *Summary:*  Clear Upgrade condition if the Operator isn't performing an upgrade.
+*https://jira.issues.couchbase.com/browse/K8S-3609[K8S-3609^]*::
 
-a| https://jira.issues.couchbase.com/browse/K8S-3659[K8S-3659^]
-a| *Summary:*  When scaling down, Cluster does not maintain balance across Server Groups.
+ Hibernation fails to bring back any Pod with error extracting image version.
 
-a| https://jira.issues.couchbase.com/browse/K8S-3696[K8S-3696^]
-a| *Summary:*  DAC prevents configuration of multiple XDCR Replications of same Buckets to different remote Clusters.
+*https://jira.issues.couchbase.com/browse/K8S-3621[K8S-3621^]*::
 
-a| https://jira.issues.couchbase.com/browse/K8S-3772[K8S-3772^]
-a| *Summary:* Self-Certification: Artifacts PVC should use `--storage-class` parameter when creating the Certification Pod.
+Shadowed Secret did not get updated.
 
-a| https://jira.issues.couchbase.com/browse/K8S-3788[K8S-3788^]
-a| *Summary:* Operator container crashes when there is a managed Scope/Collection Group added for the Ephemeral Bucket.
+*https://jira.issues.couchbase.com/browse/K8S-3632[K8S-3632^]*::
+
+Unable to set -1 for Collection-level `maxTTL`.
+
+*https://jira.issues.couchbase.com/browse/K8S-3639[K8S-3639^]*::
+
+Operator loses track of pending Pods when an Eviction of the Operator Pod occurs.
+
+*https://jira.issues.couchbase.com/browse/K8S-3641[K8S-3641^]*::
+
+ Crash in `handleVolumeExpansion` if `enableOnlineVolumeExpansion` is True but no Volume Mounts configured.
+
+*https://jira.issues.couchbase.com/browse/K8S-3655[K8S-3655^]*::
+
+ Clear Upgrade condition if the Operator isn't performing an upgrade.
+
+*https://jira.issues.couchbase.com/browse/K8S-3659[K8S-3659^]*::
+
+ When scaling down, Cluster does not maintain balance across Server Groups.
+
+*https://jira.issues.couchbase.com/browse/K8S-3696[K8S-3696^]*::
+
+ DAC prevents configuration of multiple XDCR Replications of same Buckets to different remote Clusters.
+
+*https://jira.issues.couchbase.com/browse/K8S-3772[K8S-3772^]*::
+
+Self-Certification: Artifacts PVC should use `--storage-class` parameter when creating the Certification Pod.
+
+*https://jira.issues.couchbase.com/browse/K8S-3788[K8S-3788^]*::
+
+Operator container crashes when there is a managed Scope/Collection Group added for the Ephemeral Bucket.
 
 |===
 
@@ -61,16 +73,20 @@ a| *Summary:* Operator container crashes when there is a managed Scope/Collectio
 |===
 | Issue | Description
 
-a| https://jira.issues.couchbase.com/browse/K8S-3617[K8S-3617^]
-a| *Summary:* It is not currently possible to set xref:resource/couchbasecluster.adoc#couchbaseclusters-spec-cluster-indexer-redistributeindexes[`couchbaseclusters.spec.cluster.indexer.redistributeIndexes`] from True to False during a reconciliation.
+*https://jira.issues.couchbase.com/browse/K8S-3617[K8S-3617^]*::
 
-a| https://jira.issues.couchbase.com/browse/K8S-3908[K8S-3908^]
-a| *Summary:* Metric `couchbase_operator_memory_under_management_bytes` is incorrectly showing 0.
+It is not currently possible to set xref:resource/couchbasecluster.adoc#couchbaseclusters-spec-cluster-indexer-redistributeindexes[`couchbaseclusters.spec.cluster.indexer.redistributeIndexes`] from True to False during a reconciliation.
 
-a| https://jira.issues.couchbase.com/browse/K8S-3909[K8S-3909^]
-a| *Summary:* Metric `couchbase_operator_cpu_under_management` is incorrectly showing 0.
+*https://jira.issues.couchbase.com/browse/K8S-3908[K8S-3908^]*::
 
-a| https://jira.issues.couchbase.com/browse/K8S-3910[K8S-3910^]
-a| *Summary:* Operator tries to migrate storage backend of buckets even before couchbase cluster is in 7.6.0+.
+Metric `couchbase_operator_memory_under_management_bytes` is incorrectly showing 0.
+
+*https://jira.issues.couchbase.com/browse/K8S-3909[K8S-3909^]*::
+
+Metric `couchbase_operator_cpu_under_management` is incorrectly showing 0.
+
+*https://jira.issues.couchbase.com/browse/K8S-3910[K8S-3910^]*::
+
+Operator tries to migrate storage backend of buckets even before couchbase cluster is in 7.6.0+.
 
 |===

--- a/modules/ROOT/partials/couchbase-operator-release-notes-2.8.0.adoc
+++ b/modules/ROOT/partials/couchbase-operator-release-notes-2.8.0.adoc
@@ -75,7 +75,7 @@ Operator container crashes when there is a managed Scope/Collection Group added 
 
 *https://jira.issues.couchbase.com/browse/K8S-3617[K8S-3617^]*::
 
-It is not currently possible to set xref:resource/couchbasecluster.adoc#couchbaseclusters-spec-cluster-indexer-redistributeindexes[`couchbaseclusters.spec.cluster.indexer.redistributeIndexes`] from True to False during a reconciliation.
+It's not currently possible to set xref:resource/couchbasecluster.adoc#couchbaseclusters-spec-cluster-indexer-redistributeindexes[`couchbaseclusters.spec.cluster.indexer.redistributeIndexes`] from True to False during a reconciliation.
 
 *https://jira.issues.couchbase.com/browse/K8S-3908[K8S-3908^]*::
 

--- a/modules/ROOT/partials/couchbase-operator-release-notes-2.8.0.adoc
+++ b/modules/ROOT/partials/couchbase-operator-release-notes-2.8.0.adoc
@@ -75,7 +75,7 @@ Operator container crashes when there is a managed Scope/Collection Group added 
 
 *https://jira.issues.couchbase.com/browse/K8S-3617[K8S-3617^]*::
 
-It's not currently possible to set xref:resource/couchbasecluster.adoc#couchbaseclusters-spec-cluster-indexer-redistributeindexes[`couchbaseclusters.spec.cluster.indexer.redistributeIndexes`] from True to False during a reconciliation.
+It's not possible to set xref:resource/couchbasecluster.adoc#couchbaseclusters-spec-cluster-indexer-redistributeindexes[`couchbaseclusters.spec.cluster.indexer.redistributeIndexes`] from True to False during a reconciliation.
 
 *https://jira.issues.couchbase.com/browse/K8S-3908[K8S-3908^]*::
 

--- a/modules/ROOT/partials/couchbase-operator-release-notes-2.8.0.adoc
+++ b/modules/ROOT/partials/couchbase-operator-release-notes-2.8.0.adoc
@@ -13,7 +13,7 @@ Couchbase Autonomous Operator tries to change invalid bucket configurations in a
 
 *https://jira.issues.couchbase.com/browse/K8S-3591[K8S-3591^]*::
 
-Operator crashes if Incremental Backup is missing schedule.
+Couchbase Autonomous Operator crashes if Incremental Backup is missing schedule.
 
 *https://jira.issues.couchbase.com/browse/K8S-3596[K8S-3596^]*::
 

--- a/modules/ROOT/partials/couchbase-operator-release-notes-2.8.1.adoc
+++ b/modules/ROOT/partials/couchbase-operator-release-notes-2.8.1.adoc
@@ -11,15 +11,15 @@ This maintenance release contains fixes to issues.
 [#table-fixed-issues-v281,cols="25,66"]
 
 
-*https://jira.issues.couchbase.com/browse/K8S-3793/[K8S-3793]*::
+*https://jira.issues.couchbase.com/browse/K8S-3793/[K8S-3793^]*::
 
 Fixed a bug in Local Persistent Volume comparison logic that previously triggered unnecessary pod rebalancing when comparing existing and desired states, despite no actual differences being detected.
 
-*https://jira.issues.couchbase.com/browse/K8S-3840/[K8S-3840]*::
+*https://jira.issues.couchbase.com/browse/K8S-3840/[K8S-3840^]*::
 
 Due to ephemeral volumes removing the staging directory, backups will fail if the defaultRecoveryMethod is set to resume. The admission controller will now invalidate backups using ephemeral volumes unless the defaultRecoveryMethod is set to either purge or none.
 
-*https://jira.issues.couchbase.com/browse/K8S-3889/[K8S-3889]*::
+*https://jira.issues.couchbase.com/browse/K8S-3889/[K8S-3889^]*::
 
 Inplace upgrades are not supported prior to Couchbase Server Versions 7.2.x due to a required change in the startup files required by Couchbase Server. 
 


### PR DESCRIPTION
- Fixed side nav redundancy. This does mean we needed to drop the Autonomous Operator title due to how Antora works but it does look better now.

- Updated 2.8.0 release notes to match the 2.8.1 formatting. We updated the formatting because we're trying to make this consistent across all docs so we can automate

- Changed the opening overview wording so we don't throw too many like-terms (cloud native, CAO, CKO) at once. It should be at least a little clearer now.