### PR TITLE
[DOC-13446]: Create a release note for Couchbase Operator 2.7.1

### DIFF
--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -36,6 +36,7 @@ For large, production databases, ensure an adequate maintenance window is schedu
 For further information read the xref:concept-upgrade.adoc[Couchbase Upgrade] concepts page.
 ====
 
+include::partial$couchbase-operator-2.7.1-release-notes.adoc[]
 [#release-v270-addendum]
 == Addendum to Release 2.7.0
 

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -37,19 +37,6 @@ For further information read the xref:concept-upgrade.adoc[Couchbase Upgrade] co
 ====
 
 include::partial$couchbase-operator-2.7.1-release-notes.adoc[]
-[#release-v270-addendum]
-== Addendum to Release 2.7.0
-
-Since Couchbase Autonomous Operator 2.7.0 was released, the following issues have been identified.
-
-[#table-known-issues-v270-addendum,cols="25,66"]
-|===
-| Issue | Description
-
-a| https://issues.couchbase.com/browse/K8S-3968[K8S-3968^]
-a| *Summary:*  There is a scenario where a Pod deletion takes too long to shut down, allowing Operator to see it as still active within the Couchbase Cluster, but not existing in the Kubernetes Resource database (`etcd`).  This results in Operator classifying the Pod as an "Unknown" Pod, and summarily ejecting it from the Couchbase Cluster, which can result in a loss of Couchbase logs present on the Persistent Volumes of the Pod.
-
-|===
 
 [#release-v270]
 == Release 2.7.0

--- a/modules/ROOT/partials/couchbase-operator-2.7.1-release-notes.adoc
+++ b/modules/ROOT/partials/couchbase-operator-2.7.1-release-notes.adoc
@@ -1,0 +1,39 @@
+[#release-271]
+== Release 2.7.1 (August 2025)
+
+Couchbase Operator 2.7.1 was released in August 2025.
+This maintenance release contains fixes to issues.
+
+[#fixed-issues-v271]
+== Fixed Issues
+
+
+[#table-fixed-issues-v271,cols="25,66"]
+
+|===
+|Issue | Description
+
+
+
+| https://jira.issues.couchbase.com/browse/K8S-4038/[K8S-4038]
+
+a| In prior versions of Couchbase Operator, it was possible to set invalid values for the Indexer’s Replica Count.
+
+| https://jira.issues.couchbase.com/browse/K8S-4043/[K8S-4043]
+
+a| Fixed a bug in the comparison of the existing and desired state of Local Persistent Volumes that can cause swap rebalances of pods with no reported diff.
+
+| https://jira.issues.couchbase.com/browse/K8S-4045/[K8S-4045]
+
+a| In prior versions of Couchbase Operator, it was possible for pods to be scheduled unevenly across server groups.
+
+| https://jira.issues.couchbase.com/browse/K8S-4047/[K8S-4047]
+
+a| In previous versions of Couchbase Operator, a user was unable to configure multiple replications per bucket.  This limitation has been removed.
+
+| https://jira.issues.couchbase.com/browse/K8S-4144/[K8S-4144]
+
+a| In prior versions of Couchbase Operator, the metrics port annotation (`prometheus.io/port`) was set to 8091, even if TLS was enabled.  It will not correctly set to 18091.
+|===
+
+

--- a/modules/ROOT/partials/couchbase-operator-2.7.1-release-notes.adoc
+++ b/modules/ROOT/partials/couchbase-operator-2.7.1-release-notes.adoc
@@ -1,9 +1,6 @@
 [#release-271]
 == Release 2.7.1
 
-Couchbase Operator 2.7.1 was released in August 2025.
-This maintenance release contains fixes to issues.
-
 [#fixed-issues-v271]
 === Fixed Issues
 

--- a/modules/ROOT/partials/couchbase-operator-2.7.1-release-notes.adoc
+++ b/modules/ROOT/partials/couchbase-operator-2.7.1-release-notes.adoc
@@ -1,11 +1,11 @@
 [#release-271]
-== Release 2.7.1 (August 2025)
+== Release 2.7.1
 
 Couchbase Operator 2.7.1 was released in August 2025.
 This maintenance release contains fixes to issues.
 
 [#fixed-issues-v271]
-== Fixed Issues
+=== Fixed Issues
 
 
 [#table-fixed-issues-v271,cols="25,66"]
@@ -15,25 +15,29 @@ This maintenance release contains fixes to issues.
 
 
 
+| https://jira.issues.couchbase.com/browse/K8S-3968/[K8S-3968]
+
+a| *Summary:* There is a scenario where a Pod deletion takes too long to shut down, allowing Operator to see it as still active within the Couchbase Cluster, but not existing in the Kubernetes Resource database (`etcd`).  This results in Operator classifying the Pod as an “Unknown” Pod, and summarily ejecting it from the Couchbase Cluster, which can result in a loss of Couchbase logs present on the Persistent Volumes of the Pod.
+
 | https://jira.issues.couchbase.com/browse/K8S-4038/[K8S-4038]
 
-a| In prior versions of Couchbase Operator, it was possible to set invalid values for the Indexer’s Replica Count.
+a| *Summary:* In prior versions of Couchbase Operator, it was possible to set invalid values for the Indexer’s Replica Count.
 
 | https://jira.issues.couchbase.com/browse/K8S-4043/[K8S-4043]
 
-a| Fixed a bug in the comparison of the existing and desired state of Local Persistent Volumes that can cause swap rebalances of pods with no reported diff.
+a| *Summary:* Fixed a bug in the comparison of the existing and desired state of Local Persistent Volumes that can cause swap rebalances of pods with no reported diff.
 
 | https://jira.issues.couchbase.com/browse/K8S-4045/[K8S-4045]
 
-a| In prior versions of Couchbase Operator, it was possible for pods to be scheduled unevenly across server groups.
+a| *Summary:* In prior versions of Couchbase Operator, it was possible for pods to be scheduled unevenly across server groups.
 
 | https://jira.issues.couchbase.com/browse/K8S-4047/[K8S-4047]
 
-a| In previous versions of Couchbase Operator, a user was unable to configure multiple replications per bucket.  This limitation has been removed.
+a| *Summary:* In previous versions of Couchbase Operator, a user was unable to configure multiple replications per bucket.  This limitation has been removed.
 
 | https://jira.issues.couchbase.com/browse/K8S-4144/[K8S-4144]
 
-a| In prior versions of Couchbase Operator, the metrics port annotation (`prometheus.io/port`) was set to 8091, even if TLS was enabled.  It will not correctly set to 18091.
+a| *Summary:* In prior versions of Couchbase Operator, the metrics port annotation (`prometheus.io/port`) was set to 8091, even if TLS was enabled.  It will not correctly set to 18091.
 |===
 
 


### PR DESCRIPTION

See the release notes page for the changes.

----
Preview URL:
https://preview.docs-test.couchbase.com/docs-operator-DOC-13446-Create-release-note-for-Couchbase-Operator-2.7.1

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.