### PR TITLE
New backup annotations in CAO 2-9

### DIFF
--- a/modules/ROOT/pages/reference-annotations.adoc
+++ b/modules/ROOT/pages/reference-annotations.adoc
@@ -70,4 +70,30 @@ When set to true, the pods will be initialised with the node name as the hostnam
 == Cloud Native Gateway
 === OTLP Endpoint
 ==== `cao.couchbase.com/networking.cloudNativeGateway.otlp.endpoint`
-Used to set a custom OTLP endpoint for on Cloud Native Gateway. This annotation is applied to the cluster, and takes a string value (e.g. "https://otel:1234"). The value is passed directly to the Cloud Native Gateway container.
+
+Use this annotation to set a custom OTLP endpoint for the Cloud Native Gateway.
+Apply the annotation to the cluster with a string value such as `https://otel:1234`.
+The value is passed directly to the Cloud Native Gateway container.
+
+== Backup
+=== Additional Args
+==== `cao.couchbase.com/full.additionalArgs`
+
+Use this annotation to set additional arguments for `cbbackupmgr` in full backup jobs.
+Provide a string that includes any values supported by xref:server:backup-restore/cbbackupmgr-backup.html[`cbbackupmgr`].
+
+==== `cao.couchbase.com/incremental.additionalArgs`
+
+Use this annotation to set additional arguments for `cbbackupmgr` in incremental backup jobs.
+Provide a string that includes any values supported by xref:server:backup-restore/cbbackupmgr-backup.html[`cbbackupmgr`].
+
+==== `cao.couchbase.com/merge.additionalArgs`
+
+Use this annotation to set additional arguments for `cbbackupmgr` in merge backup jobs.
+Provide a string that includes any values supported by xref:server:backup-restore/cbbackupmgr-backup.html[`cbbackupmgr`].
+
+=== Additional Operator Backup Args
+==== `cao.couchbase.com/additionalOperatorBackupArgs`
+
+Use this annotation to set additional arguments for the backup container that are not used by `cbbackupmgr`, for example, `--force-delete-lockfile`.
+Provide a string value with the flags to set.

--- a/preview/HEAD.yml
+++ b/preview/HEAD.yml
@@ -3,4 +3,4 @@ sources:
     branches: [release/8.0]
 
   docs-operator:
-    branches: [DOC-13857-tutorial-to-detect-avx2, release/2.8]
+    branches: [DOC-13865-new-backup-annotations-cao-2-9-0, release/2.8]


### PR DESCRIPTION
DOC-13865

Preview doc:
- [Annotation Documentation](https://preview.docs-test.couchbase.com/docs-operator-DOC-13865-new-backup-annotations-cao-2-9-0/operator/current/reference-annotations.html)

---
Preview docs site [login credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords).

---
Ignore the preview yml file.
