### PR TITLE
adding annotation reference for dynamic cluster logging

### DIFF
--- a/modules/ROOT/pages/reference-annotations.adoc
+++ b/modules/ROOT/pages/reference-annotations.adoc
@@ -97,3 +97,9 @@ Provide a string that includes any values supported by xref:server:backup-restor
 
 Use this annotation to set additional arguments for the backup container that are not used by `cbbackupmgr`, for example, `--force-delete-lockfile`.
 Provide a string value with the flags to set.
+
+== Operator Logging
+=== Cluster Specific Operator Logging
+==== `cao.couchbase.com/operatorLogLevel`
+
+Use this annotation to override the default operator log level for a specific CouchbaseCluster. Valid values are `info`, `debug`, `error` and `-2`.

--- a/modules/ROOT/pages/reference-annotations.adoc
+++ b/modules/ROOT/pages/reference-annotations.adoc
@@ -102,4 +102,5 @@ Provide a string value with the flags to set.
 === Cluster Specific Operator Logging
 ==== `cao.couchbase.com/operatorLogLevel`
 
-Use this annotation to override the default operator log level for a specific CouchbaseCluster. Valid values are `info`, `debug`, `error` and `-2`.
+Use this annotation to override the default operator log level for a specific CouchbaseCluster. 
+Valid values are `info`, `debug`, `error` and `-2`.


### PR DESCRIPTION
This PR adds documentation for a new annotation which will be supported in operator 2.10 which allows users to override the operator's default log level for a specific CouchbaseCluster